### PR TITLE
access logger: read status code from HTTPError, if returned by c.Next()

### DIFF
--- a/access/logger.go
+++ b/access/logger.go
@@ -41,10 +41,17 @@ func Logger(log LogFunc) routing.Handler {
 
 		err := c.Next()
 
+		var statusCode int
+		if httpError, ok := err.(routing.HTTPError); ok {
+			statusCode = httpError.StatusCode()
+		} else {
+			statusCode = rw.Status
+		}
+
 		clientIP := getClientIP(req)
 		elapsed := float64(time.Now().Sub(startTime).Nanoseconds()) / 1e6
 		requestLine := fmt.Sprintf("%s %s %s", req.Method, req.URL.Path, req.Proto)
-		log(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, rw.Status, rw.BytesWritten)
+		log(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, statusCode, rw.BytesWritten)
 
 		return err
 	}


### PR DESCRIPTION
The access logger takes the status code, which is being logged, from the LogResponseWriter. If the c.Next() handler does not use WriteHeader, but instead returns a HTTPError, the access logger will log the request with a 200 OK status. (e.g. if serving static files and the requested file does not exist, status code in log will be 200 and not the returned 404)
To fix this, we need to check the error object returned by c.Next() and use its status code if available.