### PR TITLE
content negotiation in gddo doesnt work for parameters

### DIFF
--- a/content/negotiator.go
+++ b/content/negotiator.go
@@ -1,0 +1,171 @@
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package content
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type AcceptRange struct {
+	Type       string
+	Subtype    string
+	Weight     float64
+	Parameters map[string]string
+	raw        string // the raw string for this accept
+}
+
+func (a AcceptRange) RawString() string {
+	return a.raw
+}
+
+// https://tools.ietf.org/html/rfc7231#section-5.3.2
+// Accept = #( media-range [ accept-params ] )
+//  media-range    = ( "*/*"
+//                   / ( type "/" "*" )
+//                   / ( type "/" subtype )
+//                   ) *( OWS ";" OWS parameter )
+//  accept-params  = weight *( accept-ext )
+//  accept-ext = OWS ";" OWS token [ "=" ( token / quoted-string ) ]
+
+func AcceptMediaTypes(r *http.Request) []AcceptRange {
+	result := []AcceptRange{}
+
+	for _, v := range r.Header["Accept"] {
+		result = append(result, ParseAcceptRanges(v)...)
+	}
+
+	return result
+}
+
+func ParseAcceptRanges(accepts string) []AcceptRange {
+	result := []AcceptRange{}
+	remaining := accepts
+	for {
+		var accept string
+		accept, remaining = extractFieldAndSkipToken(remaining, ',')
+		result = append(result, ParseAcceptRange(accept))
+		if len(remaining) == 0 {
+			break
+		}
+	}
+	return result
+}
+
+func ParseAcceptRange(accept string) AcceptRange {
+	typeAndSub, rawparams := extractFieldAndSkipToken(accept, ';')
+
+	tp, subtp := extractFieldAndSkipToken(typeAndSub, '/')
+	params := extractParams(rawparams)
+
+	w := extractWeight(params)
+	return AcceptRange{Type: tp, Subtype: subtp, Parameters: params, Weight: w, raw: accept}
+}
+
+func extractWeight(params map[string]string) float64 {
+	if w, ok := params["q"]; ok {
+		res, err := strconv.ParseFloat(w, 64)
+		if err == nil {
+			return res
+		}
+	}
+	return 1 // default is 1
+}
+
+func extractParams(raw string) map[string]string {
+	params := map[string]string{}
+	rest := raw
+	for {
+		var p string
+		p, rest = extractFieldAndSkipToken(rest, ';')
+		if len(p) > 0 {
+			k, v := extractFieldAndSkipToken(p, '=')
+			params[k] = v
+		}
+		if len(rest) == 0 {
+			break
+		}
+	}
+
+	return params
+}
+
+func extractFieldAndSkipToken(s string, sep rune) (string, string) {
+	f, r := extractField(s, sep)
+	if len(r) > 0 {
+		r = r[1:]
+	}
+	return f, r
+}
+
+func extractField(s string, sep rune) (field, rest string) {
+	field = s
+	for i, v := range s {
+		if v == sep {
+			field = strings.TrimSpace(s[:i])
+			rest = strings.TrimSpace(s[i:])
+			break
+		}
+	}
+	return
+}
+
+func compareParams(params1 map[string]string, params2 map[string]string) (count int) {
+	for k1, v1 := range params1 {
+		if v2, ok := params2[k1]; ok && v1 == v2 {
+			count++
+		}
+	}
+	return count
+}
+
+func NegotiateContentType(r *http.Request, offers []string, defaultOffer string) string {
+	accepts := AcceptMediaTypes(r)
+	offerRanges := []AcceptRange{}
+	for _, off := range offers {
+		offerRanges = append(offerRanges, ParseAcceptRange(off))
+	}
+
+	return negotiateContentType(accepts, offerRanges, ParseAcceptRange(defaultOffer))
+}
+
+func negotiateContentType(accepts []AcceptRange, offers []AcceptRange, defaultOffer AcceptRange) string {
+	best := defaultOffer.RawString()
+	bestWeight := float64(0)
+	bestParams := 0
+
+	for _, offer := range offers {
+		for _, accept := range accepts {
+			// add a booster on the weights to prefer more exact matches to wildcards
+			// such that: */* = 0, x/* = 1, x/x = 2
+			booster := float64(0)
+			if accept.Type != "*" {
+				booster++
+				if accept.Subtype != "*" {
+					booster++
+				}
+			}
+
+			if bestWeight > (accept.Weight + booster) {
+				continue // we already have something better..
+			} else if accept.Type == "*" && accept.Subtype == "*" {
+				best = offer.RawString()
+				bestWeight = accept.Weight + booster
+			} else if accept.Subtype == "*" && offer.Type == accept.Type {
+				best = offer.RawString()
+				bestWeight = accept.Weight + booster
+			} else if accept.Type == offer.Type && accept.Subtype == offer.Subtype {
+				paramCount := compareParams(accept.Parameters, offer.Parameters)
+				if paramCount >= bestParams { // if it's equal this one must be better, since the weight was better..
+					best = offer.RawString()
+					bestWeight = accept.Weight + booster
+					bestParams = paramCount
+				}
+			}
+		}
+	}
+
+	return best
+}

--- a/content/negotiator_test.go
+++ b/content/negotiator_test.go
@@ -1,0 +1,102 @@
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package content
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentNegotiation(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=1;v=1")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/json;v=1", format)
+}
+
+func TestContentNegotiation2(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=0.6;v=1,application/json;v=2")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/json;v=2", format)
+}
+
+func TestContentNegotiation3(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*,application/xml")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "application/xml", format)
+}
+
+func TestAccept(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;  q=1 ; v=1,")
+	req := &http.Request{Header: header}
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(1), mtypes[0].Weight)
+	assert.Equal(t, "application", mtypes[0].Type)
+	assert.Equal(t, "json", mtypes[0].Subtype)
+	assert.Equal(t, map[string]string{"v": "1", "q": "1"}, mtypes[0].Parameters)
+}
+
+func TestAcceptMultiple(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "application/json;q=1;v=1, application/json;v=2,   text/html")
+	req := &http.Request{Header: header}
+
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(1), mtypes[0].Weight)
+	assert.Equal(t, "application", mtypes[0].Type)
+	assert.Equal(t, "json", mtypes[0].Subtype)
+	assert.Equal(t, map[string]string{"v": "1", "q": "1"}, mtypes[0].Parameters)
+
+	assert.Equal(t, float64(1), mtypes[1].Weight)
+	assert.Equal(t, "application", mtypes[1].Type)
+	assert.Equal(t, "json", mtypes[1].Subtype)
+	assert.Equal(t, map[string]string{"v": "2"}, mtypes[1].Parameters)
+
+	assert.Equal(t, float64(1), mtypes[2].Weight)
+	assert.Equal(t, "text", mtypes[2].Type)
+	assert.Equal(t, "html", mtypes[2].Subtype)
+	assert.Equal(t, map[string]string{}, mtypes[2].Parameters)
+}
+
+func TestAcceptElaborate(t *testing.T) {
+	a := `text/plain; q=0.5, text/html, 
+          text/x-dvi; q=0.8, text/x-c`
+
+	header := http.Header{}
+	header.Set("Accept", a)
+	req := &http.Request{Header: header}
+	mtypes := AcceptMediaTypes(req)
+
+	assert.Equal(t, float64(0.5), mtypes[0].Weight)
+	assert.Equal(t, "text", mtypes[0].Type)
+	assert.Equal(t, "plain", mtypes[0].Subtype)
+
+	assert.Equal(t, float64(1), mtypes[1].Weight)
+	assert.Equal(t, "text", mtypes[1].Type)
+	assert.Equal(t, "html", mtypes[1].Subtype)
+
+	assert.Equal(t, float64(0.8), mtypes[2].Weight)
+	assert.Equal(t, "text", mtypes[2].Type)
+	assert.Equal(t, "x-dvi", mtypes[2].Subtype)
+
+	assert.Equal(t, float64(1), mtypes[3].Weight)
+	assert.Equal(t, "text", mtypes[3].Type)
+	assert.Equal(t, "x-c", mtypes[3].Subtype)
+}

--- a/content/type.go
+++ b/content/type.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 
 	"github.com/go-ozzo/ozzo-routing"
-	"github.com/golang/gddo/httputil"
 )
 
 // MIME types
@@ -53,7 +52,7 @@ func TypeNegotiator(formats ...string) routing.Handler {
 	}
 
 	return func(c *routing.Context) error {
-		format := httputil.NegotiateContentType(c.Request, formats, formats[0])
+		format := NegotiateContentType(c.Request, formats, formats[0])
 		DataWriters[format].SetHeader(c.Response)
 		c.SetDataWriter(DataWriters[format])
 		return nil

--- a/content/type_test.go
+++ b/content/type_test.go
@@ -78,3 +78,64 @@ func TestTypeNegotiator(t *testing.T) {
 		TypeNegotiator("unknown")
 	})
 }
+
+var (
+	v1JSON = "application/json;v=1"
+	v2JSON = "application/json;v=2"
+)
+
+type JSONDataWriter1 struct {
+	JSONDataWriter
+}
+
+func (w *JSONDataWriter1) SetHeader(res http.ResponseWriter) {
+	res.Header().Set("Content-Type", v1JSON)
+}
+
+type JSONDataWriter2 struct {
+	JSONDataWriter
+}
+
+func (w *JSONDataWriter2) SetHeader(res http.ResponseWriter) {
+	res.Header().Set("Content-Type", v2JSON)
+}
+
+func TestTypeNegotiatorWithVersion(t *testing.T) {
+
+	req, _ := http.NewRequest("GET", "/users/", nil)
+	req.Header.Set("Accept", "application/xml,"+v1JSON)
+
+	// test no arguments
+	res := httptest.NewRecorder()
+	c := routing.NewContext(res, req)
+	h := TypeNegotiator()
+	assert.Nil(t, h(c))
+	c.Write("xyz")
+	assert.Equal(t, "text/html; charset=UTF-8", res.Header().Get("Content-Type"))
+	assert.Equal(t, "xyz", res.Body.String())
+
+	DataWriters[v1JSON] = &JSONDataWriter1{}
+	DataWriters[v2JSON] = &JSONDataWriter2{}
+
+	// test format chosen based on Accept
+	res = httptest.NewRecorder()
+	c = routing.NewContext(res, req)
+	h = TypeNegotiator(v2JSON, v1JSON, XML)
+	assert.Nil(t, h(c))
+	assert.Nil(t, c.Write("xyz"))
+	assert.Equal(t, "application/json;v=1", res.Header().Get("Content-Type"))
+	assert.Equal(t, `"xyz"`+"\n", res.Body.String())
+
+	// test default format used when no match
+	req.Header.Set("Accept", "application/pdf")
+	res = httptest.NewRecorder()
+	c = routing.NewContext(res, req)
+	assert.Nil(t, h(c))
+	assert.Nil(t, c.Write("xyz"))
+	assert.Equal(t, v2JSON, res.Header().Get("Content-Type"))
+	assert.Equal(t, "\"xyz\"\n", res.Body.String())
+
+	assert.Panics(t, func() {
+		TypeNegotiator("unknown")
+	})
+}


### PR DESCRIPTION
The content type negotiation in gddo doesnt properly respect parameters.  It only looks for "q" and if it finds other params it doesn't properly parse the accept header.. see: https://github.com/golang/gddo/blob/master/httputil/header/header.go#L185

Since the parseaccept is called from within the negotiation there is really no good way to feed it a properly parsed accept so i just reimplemented it myself and to make sure the parameters are matched.  

You can add back the old call to see the failure.
