### PR TITLE
Implement support for alternative access loggers

### DIFF
--- a/access/logger.go
+++ b/access/logger.go
@@ -75,7 +75,7 @@ func CustomLogger(loggerFunc LogWriterFunc) routing.Handler {
 //     r.Use(access.Logger(log.Printf))
 func Logger(log LogFunc) routing.Handler {
 	var logger = func(req *http.Request, rw *LogResponseWriter, elapsed float64) {
-		clientIP := getClientIP(req)
+		clientIP := GetClientIP(req)
 		requestLine := fmt.Sprintf("%s %s %s", req.Method, req.URL.String(), req.Proto)
 		log(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, rw.Status, rw.BytesWritten)
 
@@ -101,7 +101,7 @@ func (r *LogResponseWriter) WriteHeader(status int) {
 	r.ResponseWriter.WriteHeader(status)
 }
 
-func getClientIP(req *http.Request) string {
+func GetClientIP(req *http.Request) string {
 	ip := req.Header.Get("X-Real-IP")
 	if ip == "" {
 		ip = req.Header.Get("X-Forwarded-For")

--- a/access/logger.go
+++ b/access/logger.go
@@ -19,6 +19,48 @@ import (
 // LogFunc should be thread safe.
 type LogFunc func(format string, a ...interface{})
 
+// LogWriterFunc takes in the request and responseWriter objects as well
+// as a float64 containing the elapsed time since the request first passed
+// through this middleware and does whatever log writing it wants with that
+// information.
+// LogWriterFunc should be thread safe.
+type LogWriterFunc func(req *http.Request, res *LogResponseWriter, elapsed float64)
+
+// CustomLogger returns a handler that calls the LogWriterFunc passed to it for every request.
+// The LogWriterFunc is provided with the http.Request and LogResponseWriter objects for the
+// request, as well as the elapsed time since the request first came through the middleware.
+// LogWriterFunc can then do whatever logging it needs to do.
+//
+//     import (
+//         "log"
+//         "github.com/go-ozzo/ozzo-routing"
+//         "github.com/go-ozzo/ozzo-routing/access"
+//         "net/http"
+//     )
+//
+//     func myCustomLogger(req http.Context, res access.LogResponseWriter, elapsed int64) {
+//         // Do something with the request, response, and elapsed time data here
+//     }
+//     r := routing.New()
+//     r.Use(access.CustomLogger(myCustomLogger))
+func CustomLogger(loggerFunc LogWriterFunc) routing.Handler {
+	return func(c *routing.Context) error {
+		startTime := time.Now()
+
+		req := c.Request
+		rw := &LogResponseWriter{c.Response, http.StatusOK, 0}
+		c.Response = rw
+
+		err := c.Next()
+
+		elapsed := float64(time.Now().Sub(startTime).Nanoseconds()) / 1e6
+		loggerFunc(req, rw, elapsed)
+
+		return err
+	}
+
+}
+
 // Logger returns a handler that logs a message for every request.
 // The access log messages contain information including client IPs, time used to serve each request, request line,
 // response status and size.
@@ -32,22 +74,13 @@ type LogFunc func(format string, a ...interface{})
 //     r := routing.New()
 //     r.Use(access.Logger(log.Printf))
 func Logger(log LogFunc) routing.Handler {
-	return func(c *routing.Context) error {
-		startTime := time.Now()
-
-		req := c.Request
-		rw := &LogResponseWriter{c.Response, http.StatusOK, 0}
-		c.Response = rw
-
-		err := c.Next()
-
+	var logger = func(req *http.Request, rw *LogResponseWriter, elapsed float64) {
 		clientIP := getClientIP(req)
-		elapsed := float64(time.Now().Sub(startTime).Nanoseconds()) / 1e6
 		requestLine := fmt.Sprintf("%s %s %s", req.Method, req.URL.String(), req.Proto)
 		log(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, rw.Status, rw.BytesWritten)
 
-		return err
 	}
+	return CustomLogger(logger)
 }
 
 // LogResponseWriter wraps http.ResponseWriter in order to capture HTTP status and response length information.

--- a/access/logger_test.go
+++ b/access/logger_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCustomLogger(t *testing.T) {
+	var buf bytes.Buffer
+	var customFunc = func(req *http.Request, rw *LogResponseWriter, elapsed float64) {
+		var logWriter = getLogger(&buf)
+		clientIP := getClientIP(req)
+		requestLine := fmt.Sprintf("%s %s %s", req.Method, req.URL.String(), req.Proto)
+		logWriter(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, rw.Status, rw.BytesWritten)
+	}
+	h := CustomLogger(customFunc)
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "http://127.0.0.1/users", nil)
+	c := routing.NewContext(res, req, h, handler1)
+	assert.NotNil(t, c.Next())
+	assert.Contains(t, buf.String(), "GET http://127.0.0.1/users")
+}
+
 func TestLogger(t *testing.T) {
 	var buf bytes.Buffer
 	h := Logger(getLogger(&buf))

--- a/access/logger_test.go
+++ b/access/logger_test.go
@@ -20,7 +20,7 @@ func TestCustomLogger(t *testing.T) {
 	var buf bytes.Buffer
 	var customFunc = func(req *http.Request, rw *LogResponseWriter, elapsed float64) {
 		var logWriter = getLogger(&buf)
-		clientIP := getClientIP(req)
+		clientIP := GetClientIP(req)
 		requestLine := fmt.Sprintf("%s %s %s", req.Method, req.URL.String(), req.Proto)
 		logWriter(`[%s] [%.3fms] %s %d %d`, clientIP, elapsed, requestLine, rw.Status, rw.BytesWritten)
 	}
@@ -62,14 +62,14 @@ func TestGetClientIP(t *testing.T) {
 	req.Header.Set("X-Forwarded-For", "192.168.100.2")
 	req.RemoteAddr = "192.168.100.3"
 
-	assert.Equal(t, "192.168.100.1", getClientIP(req))
+	assert.Equal(t, "192.168.100.1", GetClientIP(req))
 	req.Header.Del("X-Real-IP")
-	assert.Equal(t, "192.168.100.2", getClientIP(req))
+	assert.Equal(t, "192.168.100.2", GetClientIP(req))
 	req.Header.Del("X-Forwarded-For")
-	assert.Equal(t, "192.168.100.3", getClientIP(req))
+	assert.Equal(t, "192.168.100.3", GetClientIP(req))
 
 	req.RemoteAddr = "192.168.100.3:8080"
-	assert.Equal(t, "192.168.100.3", getClientIP(req))
+	assert.Equal(t, "192.168.100.3", GetClientIP(req))
 }
 
 func getLogger(buf *bytes.Buffer) LogFunc {


### PR DESCRIPTION
This commit implements additional types that allow custom loggers to be supplied for the ozzo-routing/access middleware.  The original access logger has been re-factored to use the new CustomLogger method to create the Logger method that returns the logging middleware.  In addition, a [logger that can be used to write metrics to Datadog has been created](https://github.com/jonathana/ozzo-datadog-logger) that also uses CustomLogger.

Based on the 2 loggers existing, I believe that at least for now the refactor is sensible and can be used generally for writing to different logging/metric backends. 

It might be desirable in the future to, instead of passing the actual request and response objects, to instead extract (or copy in the case of req.URL) data values into a struct that is then passed to the CustomLogger.  Absent that, it is the responsibility today of CustomLogger implementors to make sure that their use of the request and response objects is concurrency safe.  Specifically, these objects should be treated as read-only.