### PR TITLE
Empty body during a POST panics

### DIFF
--- a/context.go
+++ b/context.go
@@ -143,6 +143,9 @@ func (c *Context) URL(route string, pairs ...interface{}) string {
 // to read the request data.
 func (c *Context) Read(data interface{}) error {
 	if c.Request.Method != "GET" {
+		if c.Request.Body == nil {
+			return NewHTTPError(http.StatusBadRequest, "No request body.")
+		}
 		t := getContentType(c.Request)
 		if reader, ok := DataReaders[t]; ok {
 			return reader.Read(c.Request, data)


### PR DESCRIPTION
If a client POSTs an empty body and someone using the routing library as per examples, e.g.
```golang
if err := c.Read(&model); err != nil {
		return err
	}
```
then this actually panics with a null pointer reference rather than returning a BadRequest error. I think returning a bad request here is much safer than making routing library clients wrap every non-get in a nil-check.