### PR TITLE
Exposing Find

### DIFF
--- a/router.go
+++ b/router.go
@@ -75,12 +75,12 @@ func (r *Router) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	c := r.pool.Get().(*Context)
 	c.init(res, req)
 	if r.UseEscapedPath {
-		c.handlers, c.pnames = r.Find(req.Method, r.normalizeRequestPath(req.URL.EscapedPath()), c.pvalues)
+		c.handlers, c.pnames = r.find(req.Method, r.normalizeRequestPath(req.URL.EscapedPath()), c.pvalues)
 		for i, v := range c.pvalues {
 			c.pvalues[i], _ = url.QueryUnescape(v)
 		}
 	} else {
-		c.handlers, c.pnames = r.Find(req.Method, r.normalizeRequestPath(req.URL.Path), c.pvalues)
+		c.handlers, c.pnames = r.find(req.Method, r.normalizeRequestPath(req.URL.Path), c.pvalues)
 	}
 	if err := c.Next(); err != nil {
 		r.handleError(c, err)
@@ -112,16 +112,15 @@ func (r *Router) NotFound(handlers ...Handler) {
 	r.notFoundHandlers = combineHandlers(r.handlers, r.notFound)
 }
 
-// Find determines the handler and parameters to use for a specified method and path.
-func (r *Router) Find(method, path string, pvalues []string) (handlers []Handler, pnames []string) {
-	var hh interface{}
-	if store := r.stores[method]; store != nil {
-		hh, pnames = store.Get(path, pvalues)
+// Find determines the handlers and parameters to use for a specified method and path.
+func (r *Router) Find(method, path string) (handlers []Handler, params map[string]string) {
+	pvalues := make([]string, r.maxParams)
+	handlers, pnames := r.find(method, path, pvalues)
+	params = make(map[string]string, len(pnames))
+	for i, n := range pnames {
+		params[n] = pvalues[i]
 	}
-	if hh != nil {
-		return hh.([]Handler), pnames
-	}
-	return r.notFoundHandlers, pnames
+	return handlers, params
 }
 
 // handleError is the error handler for handling any unhandled errors.
@@ -152,6 +151,17 @@ func (r *Router) addRoute(route *Route, handlers []Handler) {
 	if n := store.Add(path, handlers); n > r.maxParams {
 		r.maxParams = n
 	}
+}
+
+func (r *Router) find(method, path string, pvalues []string) (handlers []Handler, pnames []string) {
+	var hh interface{}
+	if store := r.stores[method]; store != nil {
+		hh, pnames = store.Get(path, pvalues)
+	}
+	if hh != nil {
+		return hh.([]Handler), pnames
+	}
+	return r.notFoundHandlers, pnames
 }
 
 func (r *Router) findAllowedMethods(path string) map[string]bool {

--- a/router_test.go
+++ b/router_test.go
@@ -76,7 +76,7 @@ func TestRouterFind(t *testing.T) {
 	r := New()
 	r.add("GET", "/users/<id>", []Handler{NotFoundHandler})
 	pvalues := make([]string, 10)
-	handlers, pnames := r.find("GET", "/users/1", pvalues)
+	handlers, pnames := r.Find("GET", "/users/1", pvalues)
 	assert.Equal(t, 1, len(handlers))
 	if assert.Equal(t, 1, len(pnames)) {
 		assert.Equal(t, "id", pnames[0])

--- a/router_test.go
+++ b/router_test.go
@@ -75,13 +75,11 @@ func TestRouterAdd(t *testing.T) {
 func TestRouterFind(t *testing.T) {
 	r := New()
 	r.add("GET", "/users/<id>", []Handler{NotFoundHandler})
-	pvalues := make([]string, 10)
-	handlers, pnames := r.Find("GET", "/users/1", pvalues)
+	handlers, params := r.Find("GET", "/users/1")
 	assert.Equal(t, 1, len(handlers))
-	if assert.Equal(t, 1, len(pnames)) {
-		assert.Equal(t, "id", pnames[0])
+	if assert.Equal(t, 1, len(params)) {
+		assert.Equal(t, "1", params["id"])
 	}
-	assert.Equal(t, "1", pvalues[0])
 }
 
 func TestRouterNormalizeRequestPath(t *testing.T) {


### PR DESCRIPTION
I raised a ticket to discuss this proposal about a month ago:

https://github.com/go-ozzo/ozzo-routing/issues/42

The change is very slight, just exposing the Find method on the router. The purpose of this is to allow an API to map an internal or "self" link to a database entity, by determining the ID of the object that link represents.

I've also moved the Find method up in its file to keep all the public methods together.