### PR TITLE
Fix negotiateContentType , if not match, the default should used 

### DIFF
--- a/content/negotiator.go
+++ b/content/negotiator.go
@@ -138,7 +138,7 @@ func NegotiateContentType(r *http.Request, offers []string, defaultOffer string)
 
 func negotiateContentType(accepts []AcceptRange, offers []AcceptRange, defaultOffer AcceptRange) string {
 	best := defaultOffer.RawString()
-	bestWeight := float64(0)
+	bestWeight := defaultOffer.Weight
 	bestParams := 0
 
 	for _, offer := range offers {
@@ -155,10 +155,10 @@ func negotiateContentType(accepts []AcceptRange, offers []AcceptRange, defaultOf
 
 			if bestWeight > (accept.Weight + booster) {
 				continue // we already have something better..
-			} else if accept.Type == "*" && accept.Subtype == "*" {
+			} else if accept.Type == "*" && accept.Subtype == "*" && ((accept.Weight + booster) > bestWeight) {
 				best = offer.RawString()
 				bestWeight = accept.Weight + booster
-			} else if accept.Subtype == "*" && offer.Type == accept.Type {
+			} else if accept.Subtype == "*" && offer.Type == accept.Type && ((accept.Weight + booster) > bestWeight) {
 				best = offer.RawString()
 				bestWeight = accept.Weight + booster
 			} else if accept.Type == offer.Type && accept.Subtype == offer.Subtype {

--- a/content/negotiator_test.go
+++ b/content/negotiator_test.go
@@ -40,6 +40,25 @@ func TestContentNegotiation3(t *testing.T) {
 	assert.Equal(t, "application/xml", format)
 }
 
+func TestContentNegotiation4(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml"}
+	format := NegotiateContentType(req, offers, "application/json")
+	assert.Equal(t, "application/json", format)
+}
+
+func TestContentNegotiation5(t *testing.T) {
+	header := http.Header{}
+	header.Set("Accept", "*/*")
+	req := &http.Request{Header: header}
+
+	offers := []string{"application/json", "application/xml", "application/json;v=1", "application/json;v=2"}
+	format := NegotiateContentType(req, offers, "text/html")
+	assert.Equal(t, "text/html", format)
+}
 func TestAccept(t *testing.T) {
 	header := http.Header{}
 	header.Set("Accept", "application/json;  q=1 ; v=1,")


### PR DESCRIPTION
If no match is found, the default should be used, to not break the behavior of TypeNegotiator(formats ...string) https://github.com/go-ozzo/ozzo-routing/blob/master/content/type.go#L44.
```
// TypeNegotiator returns a content type negotiation handler.
//
// The method takes a list of response MIME types that are supported by the application.
// The negotiator will determine the best response MIME type to use by checking the "Accept" HTTP header.
// If no match is found, the first MIME type will be used.

```

Test Result:
```
$ go test --cover ./...
ok  	github.com/go-ozzo/ozzo-routing/v2	7.300s	coverage: 92.4% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/access	3.267s	coverage: 100.0% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/auth	6.029s	coverage: 96.0% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/content	5.365s	coverage: 95.8% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/cors	6.704s	coverage: 100.0% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/fault	3.969s	coverage: 100.0% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/file	4.695s	coverage: 93.2% of statements
ok  	github.com/go-ozzo/ozzo-routing/v2/slash	2.537s	coverage: 100.0% of statements

```